### PR TITLE
Add ERC20-based FundingVault contract

### DIFF
--- a/packages/hardhat/contracts/FundingVault.sol
+++ b/packages/hardhat/contracts/FundingVault.sol
@@ -54,7 +54,8 @@ contract FundingVault is ERC20 {
     uint256 public proofOfFundingTokenAmount; // The initial  proof-of-funding token amount which will be in fundingVault
     uint256 public timestamp; // The date limit until which withdrawal or after which refund is allowed.
     uint256 public immutable minFundingAmount; // The minimum amount of ETH required in the contract to enable withdrawal.
-    uint256 public exchangeRate; // The exchange rate of ETH per token
+    uint256 public exchangeRate; // The exchange rate numerator of ETH per token
+     uint256 public constant DENOMINATOR = 100000; // Fixed denominator
     address public withdrawalAddress; // WithdrawalAddress is also considered as owner of the Vault. 
     address private developerFeeAddress; // Developer address
     uint256 private developerFeePercentage; // Developer percentage in funds collected
@@ -132,7 +133,7 @@ contract FundingVault is ERC20 {
      */
     function purchaseTokens() external payable {
 
-        uint256 tokenAmount = msg.value * exchangeRate;
+        uint256 tokenAmount = (msg.value * exchangeRate) / DENOMINATOR;
 
         if (proofOfFundingToken.balanceOf(address(this)) - totalSupply() < tokenAmount) revert NotEnoughTokens();
         proofOfFundingToken.safeTransfer(msg.sender,tokenAmount);
@@ -153,7 +154,7 @@ contract FundingVault is ERC20 {
         if (amountRaised >= minFundingAmount) revert MinFundingAmountReached();
         
         uint256 voucherAmount = balanceOf(msg.sender);
-        uint256 refundAmount = voucherAmount / exchangeRate;
+        uint256 refundAmount = (voucherAmount * DENOMINATOR) / exchangeRate;
 
         _burn(msg.sender, voucherAmount);
        

--- a/packages/hardhat/contracts/FundingVaultERC20.sol
+++ b/packages/hardhat/contracts/FundingVaultERC20.sol
@@ -16,7 +16,7 @@ contract FundingVault {
 	error DeadlineNotPassed();
 	error NotEnoughTokens();
 	error OwnerOnly();
-    erro InvalidAmount();
+    error InvalidAmount();
 
 	// State Variables
 	using SafeERC20 for IERC20;
@@ -134,12 +134,20 @@ contract FundingVault {
 		);
 	}
 
+	
 	function addTokens(uint256 additionalTokens) external onlyOwner {
 		proofOfFundingToken.safeTransferFrom(
 			msg.sender,
 			address(this),
 			additionalTokens
 		);
+	}
+
+    function redeem() external{
+		if(block.timestamp < timestamp) revert DeadlineNotPassed();
+		uint256 voucherAmount=proofOfFundingToken.balanceOf(msg.sender);
+		proofOfFundingToken.safeTransferFrom(msg.sender, address(this), voucherAmount);
+		fundingToken.safeTransfer(msg.sender, voucherAmount);
 	}
 
 	function getVault() external view returns (Vault memory) {

--- a/packages/hardhat/contracts/FundingVaultERC20.sol
+++ b/packages/hardhat/contracts/FundingVaultERC20.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AEL
+pragma solidity ^0.8.18;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title FundingVault
+ * @author
+ * @notice A contract that allows users to deposit ERC20 tokens and receive proof-of-funding tokens in return. Project owners can withdraw funds once the minimum funding amount is reached.
+ */
+contract FundingVault {
+	// Errors
+	error MinFundingAmountReached();
+	error MinFundingAmountNotReached();
+	error DeadlineNotPassed();
+	error NotEnoughTokens();
+	error OwnerOnly();
+
+	// State Variables
+	using SafeERC20 for IERC20;
+
+	IERC20 public immutable fundingToken;
+	IERC20 public immutable proofOfFundingToken;
+	uint256 public immutable minFundingAmount;
+	uint256 public proofOfFundingTokenAmount;
+	uint256 public timestamp;
+	uint256 public exchangeRate;
+	address public withdrawalAddress;
+	address private developerFeeAddress;
+	uint256 private developerFeePercentage;
+	string public projectURL;
+	string public projectTitle;
+	string public projectDescription;
+	uint256 private amountRaised;
+
+	struct Vault {
+		address withdrawalAddress;
+		address proofOfFundingToken;
+		uint256 proofOfFundingTokenAmount;
+		uint256 minFundingAmount;
+		uint256 timestamp;
+		uint256 exchangeRate;
+		string projectURL;
+		string projectTitle;
+		string projectDescription;
+		address fundingToken;
+		address developerFeeAddress;
+		uint256 developerFeePercentage;
+	}
+
+	// Events
+	event TokensPurchased(address indexed from, uint256 indexed amount);
+	event Refund(address indexed user, uint256 indexed amount);
+	event FundsWithdrawn(address indexed user, uint256 amount);
+
+	modifier onlyOwner() {
+		if (msg.sender != withdrawalAddress) revert OwnerOnly();
+		_;
+	}
+
+	constructor(Vault memory params) {
+		proofOfFundingToken = IERC20(params.proofOfFundingToken);
+		fundingToken = IERC20(params.fundingToken);
+		proofOfFundingTokenAmount = params.proofOfFundingTokenAmount;
+		minFundingAmount = params.minFundingAmount;
+		timestamp = params.timestamp;
+		exchangeRate = params.exchangeRate;
+		withdrawalAddress = params.withdrawalAddress;
+		developerFeeAddress = params.developerFeeAddress;
+		developerFeePercentage = params.developerFeePercentage;
+		projectURL = params.projectURL;
+		projectTitle = params.projectTitle;
+		projectDescription = params.projectDescription;
+	}
+
+	function purchaseTokens(uint256 amount) external {
+		if (amount == 0) revert MinFundingAmountNotReached();
+
+		uint256 tokenAmount = amount * exchangeRate;
+		if (proofOfFundingToken.balanceOf(address(this)) < tokenAmount)
+			revert NotEnoughTokens();
+
+		fundingToken.safeTransferFrom(msg.sender, address(this), amount);
+		proofOfFundingToken.safeTransfer(msg.sender, tokenAmount);
+
+		amountRaised += amount;
+
+		emit TokensPurchased(msg.sender, tokenAmount);
+	}
+
+	function refundTokens() external {
+		if (block.timestamp < timestamp) revert DeadlineNotPassed();
+		if (amountRaised >= minFundingAmount) revert MinFundingAmountReached();
+
+		uint256 tokensHeld = proofOfFundingToken.balanceOf(msg.sender);
+		uint256 refundAmount = tokensHeld / exchangeRate;
+
+		proofOfFundingToken.safeTransferFrom(
+			msg.sender,
+			address(this),
+			tokensHeld
+		);
+		fundingToken.safeTransfer(msg.sender, refundAmount);
+
+		emit Refund(msg.sender, refundAmount);
+	}
+
+	function withdrawFunds() external onlyOwner {
+		if (amountRaised < minFundingAmount)
+			revert MinFundingAmountNotReached();
+
+		uint256 developerFee = (amountRaised * developerFeePercentage) / 100;
+		uint256 amountToWithdraw = amountRaised - developerFee;
+
+		fundingToken.safeTransfer(developerFeeAddress, developerFee);
+		fundingToken.safeTransfer(withdrawalAddress, amountToWithdraw);
+
+		emit FundsWithdrawn(msg.sender, amountToWithdraw);
+	}
+
+	function withdrawUnsoldTokens(
+		uint256 UnsoldTokenAmount
+	) external onlyOwner {
+		if (proofOfFundingToken.balanceOf(address(this)) < UnsoldTokenAmount)
+			revert NotEnoughTokens();
+
+		proofOfFundingToken.safeTransferFrom(
+			address(this),
+			withdrawalAddress,
+			UnsoldTokenAmount
+		);
+	}
+
+	function addTokens(uint256 additionalTokens) external onlyOwner {
+		proofOfFundingToken.safeTransferFrom(
+			msg.sender,
+			address(this),
+			additionalTokens
+		);
+	}
+
+	function getVault() external view returns (Vault memory) {
+		return
+			Vault({
+				withdrawalAddress: withdrawalAddress,
+				proofOfFundingToken: address(proofOfFundingToken),
+				proofOfFundingTokenAmount: proofOfFundingTokenAmount,
+				minFundingAmount: minFundingAmount,
+				timestamp: timestamp,
+				exchangeRate: exchangeRate,
+				projectURL: projectURL,
+				projectTitle: projectTitle,
+				projectDescription: projectDescription,
+				fundingToken: address(fundingToken),
+				developerFeeAddress: developerFeeAddress,
+				developerFeePercentage: developerFeePercentage
+			});
+	}
+}

--- a/packages/hardhat/contracts/FundingVaultERC20.sol
+++ b/packages/hardhat/contracts/FundingVaultERC20.sol
@@ -26,7 +26,7 @@ contract FundingVault {
 	uint256 public immutable minFundingAmount;
 	uint256 public proofOfFundingTokenAmount;
 	uint256 public timestamp;
-	uint256 public immutable exchangeRate; // Numerator
+	uint256 public  exchangeRate; // Numerator
     uint256 public constant DENOMINATOR = 100000; // Fixed denominator
 	address public withdrawalAddress;
 	address private developerFeeAddress;


### PR DESCRIPTION
This PR introduces a new implementation of the FundingVault contract that allows users to contribute ERC20 tokens instead of native blockchain tokens (e.g., ETH). This feature makes the FundingVault more versatile and usable across a wider range of scenarios. The key changes include:

ERC20 Token Support:

Replaced msg.value with an IERC20 fundingToken parameter for user contributions.
Users can purchase "proof-of-funding tokens" (PFT) by transferring ERC20 tokens to the vault.
Added an exchangeRate parameter to determine how many PFT tokens are issued per unit of ERC20 funding token.
Refactored purchaseTokens and refundTokens:

purchaseTokens: Users call this function to exchange ERC20 funding tokens for PFT tokens.
refundTokens: Users can redeem their PFT tokens for ERC20 funding tokens if the funding goal is not reached.
Developer Fees and Withdrawal:

Ensures the project owner can withdraw funds only if the minimum funding goal is met.
Automatically deducts a configurable developer fee when funds are withdrawn.