### PR TITLE
Erc20 funding vault clean

### DIFF
--- a/packages/hardhat/contracts/FundingVaultERC20.sol
+++ b/packages/hardhat/contracts/FundingVaultERC20.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: AEL
+
+/**
+ * Layout of the contract
+ * version
+ * imports
+ * errors
+ * interfaces, libraries, and contracts
+ * type declarations
+ * state variables
+ * events
+ * modifiers
+ * functions
+ *
+ * layout of functions
+ * constructor
+ * receive function
+ * fallback function
+ * external functions
+ * public functions
+ * internal functions
+ * private functions
+ * view functions
+ * pure functions
+ * getters
+ */
+pragma solidity ^0.8.18;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title FundingVault
+ * @author Muhammad Zain Nasir
+ * @notice A contract that allows users to deposit funds and receive proof-of-funding token in return box creator can call WithdrawFunds if there enough funds collected
+ */
+contract FundingVault is ERC20 {
+
+    // Errors //
+    error MinFundingAmountReached();
+    error MinFundingAmountNotReached();
+    error DeadlineNotPassed(); 
+    error NotEnoughTokens(); 
+    error EthTransferFailed();
+    error EthTransferToDeveloperFailed();
+    error EthTransferToWithdrawalFailed();
+    error OwnerOnly();
+
+
+    // State Variables //
+    using SafeERC20 for IERC20;
+    IERC20 public immutable proofOfFundingToken; // The token that will be used as proof-of-funding token to incentivise contributions
+    uint256 public proofOfFundingTokenAmount; // The initial  proof-of-funding token amount which will be in fundingVault
+    uint256 public timestamp; // The date limit until which withdrawal or after which refund is allowed.
+    uint256 public immutable minFundingAmount; // The minimum amount of ETH required in the contract to enable withdrawal.
+    uint256 public exchangeRate; // The exchange rate of ETH per token
+    address public withdrawalAddress; // WithdrawalAddress is also considered as owner of the Vault. 
+    address private developerFeeAddress; // Developer address
+    uint256 private developerFeePercentage; // Developer percentage in funds collected
+    string  public projectURL; // A link or hash containing the project's information (e.g., GitHub repository).
+    string public projectTitle; // Name of the Project
+    string public projectDescription; // Short description of the project
+    uint256 private amountRaised; // Variable to know if minimum funding raised or not
+
+
+    /** 
+    * @dev A vault is represented as a struct  
+    */ 
+
+    struct Vault {
+        address withdrawalAddress;
+        address proofOfFundingToken;
+        uint256 proofOfFundingTokenAmount;  
+        uint256 minFundingAmount;
+        uint256 timestamp;
+        uint256 exchangeRate;
+        string projectURL;
+        string projectTitle;
+        string projectDescription;
+    }
+    
+
+    // Events //
+    event TokensPurchased(address indexed from, uint256 indexed amount);
+    event Refund(address indexed user, uint256 indexed amount);
+    event FundsWithdrawn(address indexed user, uint256 amount);
+
+
+    // Modifiers //
+
+    modifier onlyOwner {
+        if (msg.sender != withdrawalAddress)  revert OwnerOnly();
+        _;
+    }
+
+
+    // Functions //
+    
+     constructor (
+        address _proofOfFundingToken, // The token that will be used as proof-of-funding token to incentivise contributions
+        uint256 _proofOfFundingTokenAmount,  // The initial  proof-of-funding token amount which will be in fundingVault
+        uint256 _minFundingAmount, // The minimum amount required to make withdraw of funds possible
+        uint256 _timestamp, // The date (block height) limit until which withdrawal or after which refund is allowed.
+        uint256 _exchangeRate, // The exchange rate of eth per token. 
+        address _withdrawalAddress, // The address for withdrawal of funds
+        address _developerFeeAddress, // The address for the developer fee
+        uint256 _developerFeePercentage, // The percentage fee for the developer.
+        string memory _projectURL, // A link or hash containing the project's information (e.g., GitHub repository).
+        string memory _projectTitle, // Name of the Project
+        string memory _projectDescription // Short description of the project
+    )ERC20("Voucher", "VCHR") {
+        
+        proofOfFundingToken  = IERC20(_proofOfFundingToken);
+        proofOfFundingTokenAmount  = _proofOfFundingTokenAmount ;
+        minFundingAmount = _minFundingAmount;
+        timestamp = _timestamp;
+        exchangeRate = _exchangeRate;
+        withdrawalAddress = _withdrawalAddress;
+        developerFeeAddress =  _developerFeeAddress;
+        developerFeePercentage = _developerFeePercentage;
+        projectURL = _projectURL;
+        projectTitle = _projectTitle;
+        projectDescription = _projectDescription;
+        projectTitle = _projectTitle;
+        projectDescription = _projectDescription;
+    }
+
+    
+    /**
+     * @dev Allows users to deposit Ether and purchase proof-of-funding token based on exchange rate
+     */
+    function purchaseTokens() external payable {
+
+        uint256 tokenAmount = msg.value * exchangeRate;
+
+        if (proofOfFundingToken.balanceOf(address(this)) - totalSupply() < tokenAmount) revert NotEnoughTokens();
+        proofOfFundingToken.safeTransfer(msg.sender,tokenAmount);
+
+        amountRaised = amountRaised + msg.value;
+        
+        emit TokensPurchased(msg.sender, tokenAmount);
+    }
+
+    /**
+     * @dev Allows users to exchange tokens for Eth (at exchange rate) if and only if the deadline has passed and the minimum number of tokens has not been sold.
+     */
+
+    function refundTokens() external payable{
+
+        if (block.timestamp < timestamp)  revert DeadlineNotPassed();
+        
+        if (amountRaised >= minFundingAmount) revert MinFundingAmountReached();
+        
+        uint256 voucherAmount = balanceOf(msg.sender);
+        uint256 refundAmount = voucherAmount / exchangeRate;
+
+        _burn(msg.sender, voucherAmount);
+       
+        (bool ethTransferSuccess, ) = payable(msg.sender).call{value: refundAmount}("");
+
+        if (!ethTransferSuccess)   revert EthTransferFailed(); 
+        
+        emit Refund(msg.sender, refundAmount);       
+    }
+
+    /**
+     * @dev Allows Project owners to withdraw Eth if and only if the minimum number of tokens has been sold.
+     
+     */
+
+    function withdrawFunds() external onlyOwner {
+    
+        if (amountRaised < minFundingAmount) revert MinFundingAmountNotReached();
+
+        uint256 fundsCollected = address(this).balance;
+        uint256 developerFee = (fundsCollected * developerFeePercentage) / 100;
+        uint256 amountToWithdraw = fundsCollected - developerFee;
+
+        (bool successA, ) = payable(developerFeeAddress).call{value: developerFee}("");
+
+        if (!successA) revert EthTransferToDeveloperFailed();
+
+        (bool successB, ) = payable(withdrawalAddress).call{value: amountToWithdraw}("");
+
+        if (!successB) revert EthTransferToWithdrawalFailed();
+
+        emit FundsWithdrawn(msg.sender, amountToWithdraw);
+    }
+
+    /**
+     * @dev Allows Project owners to withdraw unsold tokens from the contract at any time.
+     * @param UnsoldTokenAmount amount to withdraw
+    */
+
+     function withdrawUnsoldTokens(uint256 UnsoldTokenAmount) external onlyOwner {
+        if (proofOfFundingToken.balanceOf(address(this)) - totalSupply() < UnsoldTokenAmount) revert NotEnoughTokens();
+        
+        proofOfFundingToken.safeTransferFrom(address(this),withdrawalAddress,UnsoldTokenAmount);
+       
+     }
+
+     /**
+     * @dev Allows Project owners to  add more tokens to the contract at any time.
+     * @param additionalTokens amount to add
+    */
+    function addTokens(uint256 additionalTokens) external onlyOwner {
+        proofOfFundingToken.safeTransferFrom(msg.sender,address(this),additionalTokens);
+    }
+
+    function redeem() external {
+        if (block.timestamp < timestamp)  revert DeadlineNotPassed();
+        uint256 voucherAmount = balanceOf(msg.sender);
+        _burn(msg.sender,voucherAmount);
+        proofOfFundingToken.safeTransfer(msg.sender, voucherAmount);
+    }
+
+    /**
+     * @notice Get funding vault details
+     * @dev to access all necessary parameters of the funding vault
+     */ 
+    function getVault() external view returns(Vault memory)
+    {
+        Vault memory VaultDetails;
+        VaultDetails.withdrawalAddress = withdrawalAddress;
+        VaultDetails.proofOfFundingToken  = address(proofOfFundingToken);
+        VaultDetails.proofOfFundingTokenAmount  = proofOfFundingTokenAmount ;
+        VaultDetails.minFundingAmount = minFundingAmount;
+        VaultDetails.timestamp = timestamp;
+        VaultDetails.exchangeRate = exchangeRate;
+        VaultDetails.projectURL = projectURL;
+        VaultDetails.projectTitle = projectTitle;
+        VaultDetails.projectDescription = projectDescription;
+        return VaultDetails;
+    }
+
+}

--- a/packages/hardhat/contracts/FundingVaultERC20.sol
+++ b/packages/hardhat/contracts/FundingVaultERC20.sol
@@ -1,43 +1,75 @@
 // SPDX-License-Identifier: AEL
+
+/**
+ * Layout of the contract
+ * version
+ * imports
+ * errors
+ * interfaces, libraries, and contracts
+ * type declarations
+ * state variables
+ * events
+ * modifiers
+ * functions
+ *
+ * layout of functions
+ * constructor
+ * receive function
+ * fallback function
+ * external functions
+ * public functions
+ * internal functions
+ * private functions
+ * view functions
+ * pure functions
+ * getters
+ */
 pragma solidity ^0.8.18;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /**
  * @title FundingVault
- * @author 
+ * @author Muhammad Zain Nasir
  * @notice A contract that allows users to deposit ERC20 tokens and receive proof-of-funding tokens in return. Project owners can withdraw funds once the minimum funding amount is reached.
  */
 contract FundingVault {
-    // Errors
+
+    // Errors //
     error MinFundingAmountReached();
     error MinFundingAmountNotReached();
-    error DeadlineNotPassed();
-    error NotEnoughTokens();
+    error DeadlineNotPassed(); 
+    error NotEnoughTokens(); 
     error OwnerOnly();
 
-    // State Variables
-    using SafeERC20 for IERC20;
 
+    // State Variables //
+    using SafeERC20 for IERC20;
     IERC20 public immutable fundingToken; 
-    IERC20 public immutable proofOfFundingToken; 
-    uint256 public immutable minFundingAmount;
-    uint256 public proofOfFundingTokenAmount;
-    uint256 public timestamp;
-    uint256 public exchangeRate; 
-    address public withdrawalAddress;
-    address private developerFeeAddress;
-    uint256 private developerFeePercentage;
-    string public projectURL;
-    string public projectTitle;
-    string public projectDescription;
-    uint256 private amountRaised;
+    IERC20 public immutable proofOfFundingToken; // The token that will be used as proof-of-funding token to incentivise contributions
+    uint256 public proofOfFundingTokenAmount; // The initial  proof-of-funding token amount which will be in fundingVault
+    uint256 public timestamp; // The date limit until which withdrawal or after which refund is allowed.
+    uint256 public immutable minFundingAmount; // The minimum amount of ETH required in the contract to enable withdrawal.
+    uint256 public exchangeRate; // The exchange rate of ETH per token
+    address public withdrawalAddress; // WithdrawalAddress is also considered as owner of the Vault. 
+    address private developerFeeAddress; // Developer address
+    uint256 private developerFeePercentage; // Developer percentage in funds collected
+    string  public projectURL; // A link or hash containing the project's information (e.g., GitHub repository).
+    string public projectTitle; // Name of the Project
+    string public projectDescription; // Short description of the project
+    uint256 private amountRaised; // Variable to know if minimum funding raised or not
+
+
+    /** 
+    * @dev A vault is represented as a struct  
+    */ 
 
     struct Vault {
         address withdrawalAddress;
         address proofOfFundingToken;
-        uint256 proofOfFundingTokenAmount;
+        uint256 proofOfFundingTokenAmount;  
         uint256 minFundingAmount;
         uint256 timestamp;
         uint256 exchangeRate;
@@ -48,19 +80,26 @@ contract FundingVault {
         address developerFeeAddress;
         uint256 developerFeePercentage;
     }
+    
 
-    // Events
+    // Events //
     event TokensPurchased(address indexed from, uint256 indexed amount);
     event Refund(address indexed user, uint256 indexed amount);
     event FundsWithdrawn(address indexed user, uint256 amount);
 
-    modifier onlyOwner() {
-        if (msg.sender != withdrawalAddress) revert OwnerOnly();
+
+    // Modifiers //
+
+    modifier onlyOwner {
+        if (msg.sender != withdrawalAddress)  revert OwnerOnly();
         _;
     }
 
-    constructor(Vault memory params) {
-        proofOfFundingToken = IERC20(params.proofOfFundingToken);
+
+    // Functions //
+    
+     constructor(Vault memory params){
+         proofOfFundingToken = IERC20(params.proofOfFundingToken);
         fundingToken = IERC20(params.fundingToken);
         proofOfFundingTokenAmount = params.proofOfFundingTokenAmount;
         minFundingAmount = params.minFundingAmount;
@@ -74,8 +113,13 @@ contract FundingVault {
         projectDescription = params.projectDescription;
     }
 
-    function purchaseTokens(uint256 amount) external {
-        if (amount == 0) revert MinFundingAmountNotReached();
+    
+    /**
+     * @dev Allows users to deposit Ether and purchase proof-of-funding token based on exchange rate
+     */
+    function purchaseTokens(uint256 amount) external  {
+
+       if (amount == 0) revert MinFundingAmountNotReached();
 
         uint256 tokenAmount = amount * exchangeRate;
         if (proofOfFundingToken.balanceOf(address(this)) < tokenAmount) revert NotEnoughTokens();
@@ -88,20 +132,32 @@ contract FundingVault {
         emit TokensPurchased(msg.sender, tokenAmount);
     }
 
-    function refundTokens() external {
-        if (block.timestamp < timestamp) revert DeadlineNotPassed();
-        if (amountRaised >= minFundingAmount) revert MinFundingAmountReached();
+    /**
+     * @dev Allows users to exchange tokens for Eth (at exchange rate) if and only if the deadline has passed and the minimum number of tokens has not been sold.
+     */
 
+    function refundTokens() external payable{
+
+        if (block.timestamp < timestamp)  revert DeadlineNotPassed();
+        
+        if (amountRaised >= minFundingAmount) revert MinFundingAmountReached();
+        
         uint256 tokensHeld = proofOfFundingToken.balanceOf(msg.sender);
         uint256 refundAmount = tokensHeld / exchangeRate;
 
         proofOfFundingToken.safeTransferFrom(msg.sender, address(this), tokensHeld);
         fundingToken.safeTransfer(msg.sender, refundAmount);
 
-        emit Refund(msg.sender, refundAmount);
+        emit Refund(msg.sender, refundAmount);       
     }
 
+    /**
+     * @dev Allows Project owners to withdraw Eth if and only if the minimum number of tokens has been sold.
+     
+     */
+
     function withdrawFunds() external onlyOwner {
+    
         if (amountRaised < minFundingAmount) revert MinFundingAmountNotReached();
 
         uint256 developerFee = (amountRaised * developerFeePercentage) / 100;
@@ -109,20 +165,37 @@ contract FundingVault {
 
         fundingToken.safeTransfer(developerFeeAddress, developerFee);
         fundingToken.safeTransfer(withdrawalAddress, amountToWithdraw);
-
         emit FundsWithdrawn(msg.sender, amountToWithdraw);
+
+
+
+
     }
 
-    function withdrawUnsoldTokens(uint256 UnsoldTokenAmount) external onlyOwner {
+    /**
+     * @dev Allows Project owners to withdraw unsold tokens from the contract at any time.
+     * @param UnsoldTokenAmount amount to withdraw
+    */
+
+     function withdrawUnsoldTokens(uint256 UnsoldTokenAmount) external onlyOwner {
         if (proofOfFundingToken.balanceOf(address(this)) < UnsoldTokenAmount) revert NotEnoughTokens();
+        
+        proofOfFundingToken.safeTransferFrom(address(this),withdrawalAddress,UnsoldTokenAmount);
+       
+     }
 
-        proofOfFundingToken.safeTransferFrom(address(this), withdrawalAddress, UnsoldTokenAmount);
-    }
-
+     /**
+     * @dev Allows Project owners to  add more tokens to the contract at any time.
+     * @param additionalTokens amount to add
+    */
     function addTokens(uint256 additionalTokens) external onlyOwner {
-        proofOfFundingToken.safeTransferFrom(msg.sender, address(this), additionalTokens);
+        proofOfFundingToken.safeTransferFrom(msg.sender,address(this),additionalTokens);
     }
 
+    /**
+     * @notice Get funding vault details
+     * @dev to access all necessary parameters of the funding vault
+     */ 
     function getVault() external view returns (Vault memory) {
         return Vault({
             withdrawalAddress: withdrawalAddress,
@@ -139,4 +212,5 @@ contract FundingVault {
             developerFeePercentage: developerFeePercentage
         });
     }
+
 }

--- a/packages/hardhat/contracts/FundingVaultERC20.sol
+++ b/packages/hardhat/contracts/FundingVaultERC20.sol
@@ -1,237 +1,142 @@
 // SPDX-License-Identifier: AEL
-
-/**
- * Layout of the contract
- * version
- * imports
- * errors
- * interfaces, libraries, and contracts
- * type declarations
- * state variables
- * events
- * modifiers
- * functions
- *
- * layout of functions
- * constructor
- * receive function
- * fallback function
- * external functions
- * public functions
- * internal functions
- * private functions
- * view functions
- * pure functions
- * getters
- */
 pragma solidity ^0.8.18;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /**
  * @title FundingVault
- * @author Muhammad Zain Nasir
- * @notice A contract that allows users to deposit funds and receive proof-of-funding token in return box creator can call WithdrawFunds if there enough funds collected
+ * @author 
+ * @notice A contract that allows users to deposit ERC20 tokens and receive proof-of-funding tokens in return. Project owners can withdraw funds once the minimum funding amount is reached.
  */
-contract FundingVault is ERC20 {
-
-    // Errors //
+contract FundingVault {
+    // Errors
     error MinFundingAmountReached();
     error MinFundingAmountNotReached();
-    error DeadlineNotPassed(); 
-    error NotEnoughTokens(); 
-    error EthTransferFailed();
-    error EthTransferToDeveloperFailed();
-    error EthTransferToWithdrawalFailed();
+    error DeadlineNotPassed();
+    error NotEnoughTokens();
     error OwnerOnly();
 
-
-    // State Variables //
+    // State Variables
     using SafeERC20 for IERC20;
-    IERC20 public immutable proofOfFundingToken; // The token that will be used as proof-of-funding token to incentivise contributions
-    uint256 public proofOfFundingTokenAmount; // The initial  proof-of-funding token amount which will be in fundingVault
-    uint256 public timestamp; // The date limit until which withdrawal or after which refund is allowed.
-    uint256 public immutable minFundingAmount; // The minimum amount of ETH required in the contract to enable withdrawal.
-    uint256 public exchangeRate; // The exchange rate of ETH per token
-    address public withdrawalAddress; // WithdrawalAddress is also considered as owner of the Vault. 
-    address private developerFeeAddress; // Developer address
-    uint256 private developerFeePercentage; // Developer percentage in funds collected
-    string  public projectURL; // A link or hash containing the project's information (e.g., GitHub repository).
-    string public projectTitle; // Name of the Project
-    string public projectDescription; // Short description of the project
-    uint256 private amountRaised; // Variable to know if minimum funding raised or not
 
-
-    /** 
-    * @dev A vault is represented as a struct  
-    */ 
+    IERC20 public immutable fundingToken; 
+    IERC20 public immutable proofOfFundingToken; 
+    uint256 public immutable minFundingAmount;
+    uint256 public proofOfFundingTokenAmount;
+    uint256 public timestamp;
+    uint256 public exchangeRate; 
+    address public withdrawalAddress;
+    address private developerFeeAddress;
+    uint256 private developerFeePercentage;
+    string public projectURL;
+    string public projectTitle;
+    string public projectDescription;
+    uint256 private amountRaised;
 
     struct Vault {
         address withdrawalAddress;
         address proofOfFundingToken;
-        uint256 proofOfFundingTokenAmount;  
+        uint256 proofOfFundingTokenAmount;
         uint256 minFundingAmount;
         uint256 timestamp;
         uint256 exchangeRate;
         string projectURL;
         string projectTitle;
         string projectDescription;
+        address fundingToken;
+        address developerFeeAddress;
+        uint256 developerFeePercentage;
     }
-    
 
-    // Events //
+    // Events
     event TokensPurchased(address indexed from, uint256 indexed amount);
     event Refund(address indexed user, uint256 indexed amount);
     event FundsWithdrawn(address indexed user, uint256 amount);
 
-
-    // Modifiers //
-
-    modifier onlyOwner {
-        if (msg.sender != withdrawalAddress)  revert OwnerOnly();
+    modifier onlyOwner() {
+        if (msg.sender != withdrawalAddress) revert OwnerOnly();
         _;
     }
 
-
-    // Functions //
-    
-     constructor (
-        address _proofOfFundingToken, // The token that will be used as proof-of-funding token to incentivise contributions
-        uint256 _proofOfFundingTokenAmount,  // The initial  proof-of-funding token amount which will be in fundingVault
-        uint256 _minFundingAmount, // The minimum amount required to make withdraw of funds possible
-        uint256 _timestamp, // The date (block height) limit until which withdrawal or after which refund is allowed.
-        uint256 _exchangeRate, // The exchange rate of eth per token. 
-        address _withdrawalAddress, // The address for withdrawal of funds
-        address _developerFeeAddress, // The address for the developer fee
-        uint256 _developerFeePercentage, // The percentage fee for the developer.
-        string memory _projectURL, // A link or hash containing the project's information (e.g., GitHub repository).
-        string memory _projectTitle, // Name of the Project
-        string memory _projectDescription // Short description of the project
-    )ERC20("Voucher", "VCHR") {
-        
-        proofOfFundingToken  = IERC20(_proofOfFundingToken);
-        proofOfFundingTokenAmount  = _proofOfFundingTokenAmount ;
-        minFundingAmount = _minFundingAmount;
-        timestamp = _timestamp;
-        exchangeRate = _exchangeRate;
-        withdrawalAddress = _withdrawalAddress;
-        developerFeeAddress =  _developerFeeAddress;
-        developerFeePercentage = _developerFeePercentage;
-        projectURL = _projectURL;
-        projectTitle = _projectTitle;
-        projectDescription = _projectDescription;
-        projectTitle = _projectTitle;
-        projectDescription = _projectDescription;
+    constructor(Vault memory params) {
+        proofOfFundingToken = IERC20(params.proofOfFundingToken);
+        fundingToken = IERC20(params.fundingToken);
+        proofOfFundingTokenAmount = params.proofOfFundingTokenAmount;
+        minFundingAmount = params.minFundingAmount;
+        timestamp = params.timestamp;
+        exchangeRate = params.exchangeRate;
+        withdrawalAddress = params.withdrawalAddress;
+        developerFeeAddress = params.developerFeeAddress;
+        developerFeePercentage = params.developerFeePercentage;
+        projectURL = params.projectURL;
+        projectTitle = params.projectTitle;
+        projectDescription = params.projectDescription;
     }
 
-    
-    /**
-     * @dev Allows users to deposit Ether and purchase proof-of-funding token based on exchange rate
-     */
-    function purchaseTokens() external payable {
+    function purchaseTokens(uint256 amount) external {
+        if (amount == 0) revert MinFundingAmountNotReached();
 
-        uint256 tokenAmount = msg.value * exchangeRate;
+        uint256 tokenAmount = amount * exchangeRate;
+        if (proofOfFundingToken.balanceOf(address(this)) < tokenAmount) revert NotEnoughTokens();
 
-        if (proofOfFundingToken.balanceOf(address(this)) - totalSupply() < tokenAmount) revert NotEnoughTokens();
-        proofOfFundingToken.safeTransfer(msg.sender,tokenAmount);
+        fundingToken.safeTransferFrom(msg.sender, address(this), amount);
+        proofOfFundingToken.safeTransfer(msg.sender, tokenAmount);
 
-        amountRaised = amountRaised + msg.value;
-        
+        amountRaised += amount;
+
         emit TokensPurchased(msg.sender, tokenAmount);
     }
 
-    /**
-     * @dev Allows users to exchange tokens for Eth (at exchange rate) if and only if the deadline has passed and the minimum number of tokens has not been sold.
-     */
-
-    function refundTokens() external payable{
-
-        if (block.timestamp < timestamp)  revert DeadlineNotPassed();
-        
+    function refundTokens() external {
+        if (block.timestamp < timestamp) revert DeadlineNotPassed();
         if (amountRaised >= minFundingAmount) revert MinFundingAmountReached();
-        
-        uint256 voucherAmount = balanceOf(msg.sender);
-        uint256 refundAmount = voucherAmount / exchangeRate;
 
-        _burn(msg.sender, voucherAmount);
-       
-        (bool ethTransferSuccess, ) = payable(msg.sender).call{value: refundAmount}("");
+        uint256 tokensHeld = proofOfFundingToken.balanceOf(msg.sender);
+        uint256 refundAmount = tokensHeld / exchangeRate;
 
-        if (!ethTransferSuccess)   revert EthTransferFailed(); 
-        
-        emit Refund(msg.sender, refundAmount);       
+        proofOfFundingToken.safeTransferFrom(msg.sender, address(this), tokensHeld);
+        fundingToken.safeTransfer(msg.sender, refundAmount);
+
+        emit Refund(msg.sender, refundAmount);
     }
 
-    /**
-     * @dev Allows Project owners to withdraw Eth if and only if the minimum number of tokens has been sold.
-     
-     */
-
     function withdrawFunds() external onlyOwner {
-    
         if (amountRaised < minFundingAmount) revert MinFundingAmountNotReached();
 
-        uint256 fundsCollected = address(this).balance;
-        uint256 developerFee = (fundsCollected * developerFeePercentage) / 100;
-        uint256 amountToWithdraw = fundsCollected - developerFee;
+        uint256 developerFee = (amountRaised * developerFeePercentage) / 100;
+        uint256 amountToWithdraw = amountRaised - developerFee;
 
-        (bool successA, ) = payable(developerFeeAddress).call{value: developerFee}("");
-
-        if (!successA) revert EthTransferToDeveloperFailed();
-
-        (bool successB, ) = payable(withdrawalAddress).call{value: amountToWithdraw}("");
-
-        if (!successB) revert EthTransferToWithdrawalFailed();
+        fundingToken.safeTransfer(developerFeeAddress, developerFee);
+        fundingToken.safeTransfer(withdrawalAddress, amountToWithdraw);
 
         emit FundsWithdrawn(msg.sender, amountToWithdraw);
     }
 
-    /**
-     * @dev Allows Project owners to withdraw unsold tokens from the contract at any time.
-     * @param UnsoldTokenAmount amount to withdraw
-    */
+    function withdrawUnsoldTokens(uint256 UnsoldTokenAmount) external onlyOwner {
+        if (proofOfFundingToken.balanceOf(address(this)) < UnsoldTokenAmount) revert NotEnoughTokens();
 
-     function withdrawUnsoldTokens(uint256 UnsoldTokenAmount) external onlyOwner {
-        if (proofOfFundingToken.balanceOf(address(this)) - totalSupply() < UnsoldTokenAmount) revert NotEnoughTokens();
-        
-        proofOfFundingToken.safeTransferFrom(address(this),withdrawalAddress,UnsoldTokenAmount);
-       
-     }
+        proofOfFundingToken.safeTransferFrom(address(this), withdrawalAddress, UnsoldTokenAmount);
+    }
 
-     /**
-     * @dev Allows Project owners to  add more tokens to the contract at any time.
-     * @param additionalTokens amount to add
-    */
     function addTokens(uint256 additionalTokens) external onlyOwner {
-        proofOfFundingToken.safeTransferFrom(msg.sender,address(this),additionalTokens);
+        proofOfFundingToken.safeTransferFrom(msg.sender, address(this), additionalTokens);
     }
 
-    function redeem() external {
-        if (block.timestamp < timestamp)  revert DeadlineNotPassed();
-        uint256 voucherAmount = balanceOf(msg.sender);
-        _burn(msg.sender,voucherAmount);
-        proofOfFundingToken.safeTransfer(msg.sender, voucherAmount);
+    function getVault() external view returns (Vault memory) {
+        return Vault({
+            withdrawalAddress: withdrawalAddress,
+            proofOfFundingToken: address(proofOfFundingToken),
+            proofOfFundingTokenAmount: proofOfFundingTokenAmount,
+            minFundingAmount: minFundingAmount,
+            timestamp: timestamp,
+            exchangeRate: exchangeRate,
+            projectURL: projectURL,
+            projectTitle: projectTitle,
+            projectDescription: projectDescription,
+            fundingToken: address(fundingToken),
+            developerFeeAddress: developerFeeAddress,
+            developerFeePercentage: developerFeePercentage
+        });
     }
-
-    /**
-     * @notice Get funding vault details
-     * @dev to access all necessary parameters of the funding vault
-     */ 
-    function getVault() external view returns(Vault memory)
-    {
-        Vault memory VaultDetails;
-        VaultDetails.withdrawalAddress = withdrawalAddress;
-        VaultDetails.proofOfFundingToken  = address(proofOfFundingToken);
-        VaultDetails.proofOfFundingTokenAmount  = proofOfFundingTokenAmount ;
-        VaultDetails.minFundingAmount = minFundingAmount;
-        VaultDetails.timestamp = timestamp;
-        VaultDetails.exchangeRate = exchangeRate;
-        VaultDetails.projectURL = projectURL;
-        VaultDetails.projectTitle = projectTitle;
-        VaultDetails.projectDescription = projectDescription;
-        return VaultDetails;
-    }
-
 }


### PR DESCRIPTION
This PR introduces a new implementation of the FundingVault contract that allows users to contribute ERC20 tokens instead of native blockchain tokens (e.g., ETH). This feature makes the FundingVault more versatile and usable across a wider range of scenarios. The key changes include:

ERC20 Token Support:

Replaced msg.value with an IERC20 fundingToken parameter for user contributions.
Users can purchase "proof-of-funding tokens" (PFT) by transferring ERC20 tokens to the vault.
Added an exchangeRate parameter to determine how many PFT tokens are issued per unit of ERC20 funding token.
Refactored purchaseTokens and refundTokens:

purchaseTokens: Users call this function to exchange ERC20 funding tokens for PFT tokens.
refundTokens: Users can redeem their PFT tokens for ERC20 funding tokens if the funding goal is not reached.
Developer Fees and Withdrawal:

Ensures the project owner can withdraw funds only if the minimum funding goal is met.
Automatically deducts a configurable developer fee when funds are withdrawn.