### PR TITLE
Added _fundingToken parameter to deployFundingVault for ERC20 support

### DIFF
--- a/packages/hardhat/contracts/FundingVaultFactory.sol
+++ b/packages/hardhat/contracts/FundingVaultFactory.sol
@@ -76,6 +76,7 @@ contract FundingVaultFactory{
      * @param _projectURL A link or hash containing the project's information (e.g., GitHub repository).
      */
     function deployFundingVault (
+		address _fundingToken,
         address _proofOfFundingToken,
         uint256 _proofOfFundingTokenAmount,  
         uint256 _minFundingAmount,
@@ -101,6 +102,7 @@ contract FundingVaultFactory{
         proofOfFundingToken = IERC20(_proofOfFundingToken);
 
         FundingVault fundingVault = new FundingVault (
+		_fundingToken,
         _proofOfFundingToken,
         _proofOfFundingTokenAmount,  
         _minFundingAmount,


### PR DESCRIPTION
Added _fundingToken parameter at the beginning of the deployFundingVault function in FundingVaultFactory.sol.
Ensured _fundingToken is correctly passed when deploying a new FundingVault.
This change aligns with ERC20 support, allowing vaults to be deployed using either native ETH or ERC20 tokens.
Fixes parameter mismatch issues between the frontend and smart contract, ensuring smooth deployments.