### PR TITLE
Generalize FundingVault to ERC20 {TEAM QWERTY}

### DIFF
--- a/contracts/FundingVaultFactory.sol
+++ b/contracts/FundingVaultFactory.sol
@@ -67,8 +67,9 @@ contract FundingVaultFactory{
 
     /**
      * @param _proofOfFundingToken The token that will be used as proof-of-funding token to incentivise donators
+     * @param _fundingToken The ERC20 token used for funding the vault
      * @param _proofOfFundingTokenAmount The initial  proof-of-funding token amount which will be in fundingVault
-     * @param _minFundingAmount The minimum amount required to make withdraw of funds possible
+     * @param _minFundingAmount The minimum amount of funding tokens required to make withdraw of funds possible
      * @param _timestamp The date (block height) limit until which withdrawal or after which refund is allowed.
      * @param _withdrawalAddress The address for withdrawal of funds
      * @param _developerFeeAddress the address for the developer fee
@@ -77,6 +78,7 @@ contract FundingVaultFactory{
      */
     function deployFundingVault (
         address _proofOfFundingToken,
+        address _fundingToken,
         uint256 _proofOfFundingTokenAmount,  
         uint256 _minFundingAmount,
         uint256 _timestamp,
@@ -88,7 +90,7 @@ contract FundingVaultFactory{
         string memory _projectTitle,
         string memory _projectDescription
     ) external returns (address) {
-        if (_proofOfFundingToken == address(0) || _withdrawalAddress == address(0) || _developerFeeAddress == address(0))  revert CannotBeAZeroAddress();
+        if (_proofOfFundingToken == address(0) || _fundingToken == address(0) || _withdrawalAddress == address(0) || _developerFeeAddress == address(0))  revert CannotBeAZeroAddress();
 
         if (block.timestamp > _timestamp) revert deadlineCannotBeInThePast();
         
@@ -102,6 +104,7 @@ contract FundingVaultFactory{
 
         FundingVault fundingVault = new FundingVault (
         _proofOfFundingToken,
+        _fundingToken,
         _proofOfFundingTokenAmount,  
         _minFundingAmount,
         _timestamp,


### PR DESCRIPTION
Added an immutable fundingToken (IERC20) alongside proofOfFundingToken, and extended the Vault struct / getVault() to expose both token addresses and key parameters.​

Implemented ERC20‑aware flows:

purchaseTokens(amount): uses fundingToken.safeTransferFrom to take deposits, mints VCHR vouchers based on exchangeRate, and tracks amountRaised in funding tokens.

refundTokens(): after the deadline and if amountRaised < minFundingAmount, burns the caller’s VCHR balance and refunds the corresponding fundingToken amount.

withdrawFunds(): once amountRaised >= minFundingAmount, sends developerFeePercentage of fundingToken to developerFeeAddress and the remainder to withdrawalAddress.

redeem(): after the deadline, burns the caller’s VCHR balance and transfers an equal amount of proofOfFundingToken.​

Uses OpenZeppelin SafeERC20 for all token transfers and removes any ETH‑specific logic.​

contracts/FundingVaultFactory.sol
Updated the factory to pass both _proofOfFundingToken and _fundingToken into the new FundingVault constructor and continue emitting FundingVaultDeployed(address fundingVault).​

Fixes #11 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vaults now use an ERC20 funding token instead of native ETH; a funding token must be specified when creating a vault and is exposed in vault details.
  * Purchases and refunds operate via ERC20 transfers; purchase flow handles fee-on-transfer tokens to mint correct vouchers.
* **Bug Fixes**
  * Withdrawals protected with a guard to prevent repeated/unsafe withdrawals; unsold-token and withdrawal flows now use ERC20 transfers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->